### PR TITLE
Move babel-runtime to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,10 @@
     "url": "https://github.com/webmodules/range-at-index/issues"
   },
   "homepage": "https://github.com/webmodules/range-at-index",
-  "dependencies": {
-    "babel-runtime": "4.7.4"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel": "4.7.4",
+    "babel-runtime": "4.7.4"
     "zuul": "2"
   }
 }


### PR DESCRIPTION
Installing `babel-runtime@4.7.4` shows warn caused by old core-js.
```sh
npm WARN deprecated core-js@0.6.1: core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.
```

It seems like that this library works without babel-runtime, so I moved it to devDependencies.